### PR TITLE
simplifying the function return getArea

### DIFF
--- a/Day 1. A. Arithemetic Operators.js
+++ b/Day 1. A. Arithemetic Operators.js
@@ -30,11 +30,8 @@ function readLine() {
 *   
 *    Return a number denoting the rectangle's area.
 **/
-function getArea(length, width) {
-    let area;
-    area = length * width
-
-    return area;
+function getArea(length, width) { 
+    return length * width;
 }
 
 function getPerimeter(length, width) {


### PR DESCRIPTION
Hi :)
I simplified the return of the function, removing the creation of the variable "area".
